### PR TITLE
Simpler error handling

### DIFF
--- a/src/dal.rs
+++ b/src/dal.rs
@@ -25,13 +25,8 @@ pub fn list_passwords(conn: db::PostgresConnection) -> Result<Vec<Password>, Err
 }
 
 pub fn create_password(conn: db::PostgresConnection, password: Password) -> Result<(), Error> {
-    // try! doesn't work somehow
-    //  expected `core::result::Result<(), u64>`, found `u64`
-    match conn.execute(
+    conn.execute(
         "INSERT INTO passwords VALUES ($1, $2, $3);",
         &[&password.id, &password.name, &password.encrypted]
-    ) {
-        Ok(_) => Ok(()),
-        Err(e) => Err(e),
-    }
+    ).map(|_| ())
 }


### PR DESCRIPTION
I think this is bit nicer / less verbose than the explicit match.

Incidentally, using `try!` should also work as follows:

```
pub fn create_password(conn: db::PostgresConnection, password: Password) -> Result<(), Error> {
    try!(conn.execute(
        "INSERT INTO passwords VALUES ($1, $2, $3);",
        &[&password.id, &password.name, &password.encrypted]
    ));
    Ok(())
}
```

Note that this ignores the value returned by the `try!` expression and explicitly returns `Ok())`. 
